### PR TITLE
Add support for property initializers, generate toString and hashcode

### DIFF
--- a/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
@@ -1,0 +1,6 @@
+package com.tobrun.data.compat.example
+
+import com.tobrun.datacompat.annotation.DataCompat
+
+@DataCompat
+private data class PersonData(val name: String, val nickname: String? = null, val age: Int)

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessorProvider.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessorProvider.kt
@@ -10,7 +10,6 @@ class DataCompatProcessorProvider : SymbolProcessorProvider {
         return DataCompatProcessor(
             environment.codeGenerator,
             environment.logger,
-            environment.options
         )
     }
 }


### PR DESCRIPTION
This PR adds support for generating property intializers, toString and hashcode which is an iterative step towards becoming feature complete.

### Input

```kotlin
package com.tobrun.data.compat.example

import com.tobrun.datacompat.annotation.DataCompat

@DataCompat
private data class PersonData(val name: String, val nickname: String? = null, val age: Int)
```

### Output

```kotlin

package com.tobrun.data.compat.example

import java.util.Objects
import kotlin.Int
import kotlin.String

public class Person private constructor(
  public val name: String,
  public val nickname: String?,
  public val age: Int
) {
  public override fun toString() = "Person(name=$name, nickname=$nickname, age=$age)"

  public override fun hashCode(): Int = Objects.hash(name, nickname, age)
}

```
