### PR TITLE
add check for nullable constructor fields

### DIFF
--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -183,7 +183,7 @@ class DataCompatProcessor(
                 propertyMap.keys.joinToString(
                     prefix = "return $className(",
                     transform = {
-                        "$it!!"
+                        if (propertyMap[it]!!.isNullable) "$it" else "$it!!"
                     },
                     separator = ", ",
                     postfix = ")"


### PR DESCRIPTION
we shouldn't use `!!` operator for constructor field when it nullable

before:
```
public class Person private constructor(
    public val name: String,
    public val nickname: String?,
    public val age: Int
) {
        ...
        public fun build(): Person {
            ...
            return Person(name!!, nickname!!, age!!)
        }
}
```



after:
```
public class Person private constructor(
    public val name: String,
    public val nickname: String?,
    public val age: Int
) {
        ...
        public fun build(): Person {
            ...
            return Person(name!!, nickname, age!!)
        }
}
```
