### PR TITLE
Modularize the project 

### DIFF
--- a/annotation/build.gradle.kts
+++ b/annotation/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.tobrun.datacompat"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}

--- a/annotation/src/main/kotlin/com/tobrun/datacompat/annotation/DataCompat.kt
+++ b/annotation/src/main/kotlin/com/tobrun/datacompat/annotation/DataCompat.kt
@@ -1,0 +1,9 @@
+package com.tobrun.datacompat.annotation
+
+/**
+ * Annotation class of DataCompat.
+ * Classes annotated with this annotation are required to be Kotlin data classes with private visibility.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class DataCompat

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation(project(":processor"))
+	implementation(project(":annotation"))
     ksp(project(":processor"))
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,5 +13,6 @@ pluginManagement {
 
 rootProject.name = "data-compat"
 
+include(":annotation")
 include(":processor")
 include(":example")


### PR DESCRIPTION
By having one module for providing the annotation, have another providing the annotation processor.

This results in publishing two binaries:
 - annotation -> included in the end-result binary
 - processor -> only included during build

For example:

```gradle
dependencies {
    implementation(project(":annotation"))
    ksp(project(":processor"))
}
```