### PR TITLE
Follow-up fixes

### DIFF
--- a/example/src/main/kotlin/com/tobrun/data/compat/example/JavaTest.java
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/JavaTest.java
@@ -3,7 +3,7 @@ package com.tobrun.data.compat.example;
 public class JavaTest {
 
     public void test() {
-        Person person = new Person.Builder()
+        Person person = new Person.Builder("Extra info")
                 .setAge(31)
                 .setName("Tobrun Van Nuland")
                 .setNickname("Nurbot")

--- a/example/src/main/kotlin/com/tobrun/data/compat/example/KotlinTest.kt
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/KotlinTest.kt
@@ -3,7 +3,7 @@ package com.tobrun.data.compat.example
 class KotlinTest {
 
     fun test(){
-        val person = Person{
+        val person = Person(extraInfo = "Extra info") {
             name = "Tobrun Van Nulamd"
             nickname = "Nurbot"
             age = 31

--- a/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
@@ -28,7 +28,7 @@ private data class PersonData(
     @Default("300.0")
     val dollarAmount: Double?,
     /**
-     * Mandatory extra info.
+     * Extra info. Mandatory property.
      */
     val extraInfo: String,
 ) : SampleInterface

--- a/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
@@ -27,4 +27,8 @@ private data class PersonData(
     val euroAmount: Float,
     @Default("300.0")
     val dollarAmount: Double?,
+    /**
+     * Mandatory extra info.
+     */
+    val extraInfo: String,
 ) : SampleInterface

--- a/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
@@ -22,5 +22,9 @@ private data class PersonData(
      */
     val nickname: String?,
     @Default("42")
-    val age: Int
+    val age: Int,
+    @Default("50.2f")
+    val euroAmount: Float,
+    @Default("300.0")
+    val dollarAmount: Double?,
 ) : SampleInterface

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -236,16 +236,11 @@ class DataCompatProcessor(
                                         toClassName() == Float::class.asTypeName()
                                     val isDouble =
                                         toClassName() == Double::class.asTypeName()
-                                    if (isFloat || isDouble) {
-                                        if (isMarkedNullable && isDouble) {
-                                            "($it·?:·0.0).compareTo(other.$it·?:·0.0)·==·0"
-                                        } else if (isMarkedNullable && isFloat) {
-                                            "($it·?:·0f).compareTo(other.$it·?:·0f)·==·0"
-                                        } else {
-                                            "$it.compareTo(other.$it)·==·0"
-                                        }
-                                    } else {
-                                        "$it·==·other.$it"
+                                    when {
+                                        !isMarkedNullable && (isDouble || isFloat) -> "$it.compareTo(other.$it)·==·0"
+                                        isMarkedNullable && isDouble -> "($it·?:·0.0).compareTo(other.$it·?:·0.0)·==·0"
+                                        isMarkedNullable && isFloat -> "($it·?:·0f).compareTo(other.$it·?:·0f)·==·0"
+                                        else -> "$it·==·other.$it"
                                     }
                                 }
                             },

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -363,7 +363,8 @@ class DataCompatProcessor(
                         )
                         .addKdoc(
                             """
-                            |Set ${property.value.kDoc.trimEnd('.').lowercase()}.
+                            |Setter for ${property.value.kDoc.trimEnd('.')
+                                .replaceFirstChar { it.lowercase(Locale.getDefault()) }}.
                             |
                             |@param $propertyName
                             |@return Builder

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -363,7 +363,7 @@ class DataCompatProcessor(
                         )
                         .addKdoc(
                             """
-                            |Setter for ${property.value.kDoc.trimEnd('.')
+                            |Setter for $propertyName: ${property.value.kDoc.trimEnd('.')
                                 .replaceFirstChar { it.lowercase(Locale.getDefault()) }}.
                             |
                             |@param $propertyName

--- a/processor/src/main/kotlin/com/tobrun/datacompat/PropertyDescriptor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/PropertyDescriptor.kt
@@ -6,5 +6,4 @@ data class PropertyDescriptor(
     val typeName: TypeName,
     val mandatoryForConstructor: Boolean,
     val kDoc: String,
-    val hasActualKDoc: Boolean,
 )

--- a/processor/src/main/kotlin/com/tobrun/datacompat/PropertyDescriptor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/PropertyDescriptor.kt
@@ -1,0 +1,10 @@
+package com.tobrun.datacompat
+
+import com.squareup.kotlinpoet.TypeName
+
+data class PropertyDescriptor(
+    val typeName: TypeName,
+    val mandatoryForConstructor: Boolean,
+    val kDoc: String,
+    val hasActualKDoc: Boolean,
+)

--- a/processor/src/test/kotlin/com/tobrun/datacompat/DataCompatProcessorTest.kt
+++ b/processor/src/test/kotlin/com/tobrun/datacompat/DataCompatProcessorTest.kt
@@ -37,7 +37,11 @@ private data class PersonData(
     /**
      * Actually it's a very short description.
     */
-    val veryLongAndVeryDetailedDescription: String?
+    val veryLongAndVeryDetailedDescription: String?,
+    /**
+     * Parameter that will become constructor parameter.
+    */
+    val mandatoryDoubleWithoutDefault: Double,
 ) : EmptyInterface, EmptyInterface2
     """.trimIndent()
 )

--- a/processor/src/test/kotlin/com/tobrun/datacompat/SimpleTestContent.kt
+++ b/processor/src/test/kotlin/com/tobrun/datacompat/SimpleTestContent.kt
@@ -1,11 +1,14 @@
 package com.tobrun.datacompat
 
 internal val expectedSimpleTestContent = """
+@file:Suppress("RedundantVisibilityModifier")
+
 import java.util.Date
 import java.util.Objects
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Deprecated
+import kotlin.Double
 import kotlin.Int
 import kotlin.String
 import kotlin.Unit
@@ -21,28 +24,32 @@ import kotlin.jvm.JvmSynthetic
 @Deprecated
 public class Person private constructor(
   /**
-   * The full name.
+   * Name.
    */
   public val name: String,
   /**
-   * The nickname.
+   * Nickname.
    */
   public val nickname: String?,
   /**
-   * The age.
+   * Age.
    */
   public val age: Int,
   /**
-   * The very long and very detailed description.
    * Actually it's a very short description.
    */
-  public val veryLongAndVeryDetailedDescription: String?
+  public val veryLongAndVeryDetailedDescription: String?,
+  /**
+   * Parameter that will become constructor parameter.
+   */
+  public val mandatoryDoubleWithoutDefault: Double
 ) : EmptyInterface, EmptyInterface2 {
   /**
    * Overloaded toString function.
    */
   public override fun toString() = ""${"\""}Person(name=%name, nickname=%nickname, age=%age,
-      veryLongAndVeryDetailedDescription=%veryLongAndVeryDetailedDescription)""${"\""}.trimIndent()
+      veryLongAndVeryDetailedDescription=%veryLongAndVeryDetailedDescription,
+      mandatoryDoubleWithoutDefault=%mandatoryDoubleWithoutDefault)""${"\""}.trimIndent()
 
   /**
    * Overloaded equals function.
@@ -52,72 +59,75 @@ public class Person private constructor(
     if (javaClass != other?.javaClass) return false
     other as Person
     return name == other.name && nickname == other.nickname && age == other.age &&
-        veryLongAndVeryDetailedDescription == other.veryLongAndVeryDetailedDescription
+        veryLongAndVeryDetailedDescription == other.veryLongAndVeryDetailedDescription &&
+        mandatoryDoubleWithoutDefault.compareTo(other.mandatoryDoubleWithoutDefault) == 0
   }
 
   /**
    * Overloaded hashCode function based on all class properties.
    */
   public override fun hashCode(): Int = Objects.hash(name, nickname, age,
-      veryLongAndVeryDetailedDescription)
+      veryLongAndVeryDetailedDescription, mandatoryDoubleWithoutDefault)
 
   /**
    * Convert to Builder allowing to change class properties.
    */
-  public fun toBuilder(): Builder = Builder() .setName(name) .setNickname(nickname) .setAge(age)
+  public fun toBuilder(): Builder = Builder(mandatoryDoubleWithoutDefault) .setName(name)
+      .setNickname(nickname) .setAge(age)
       .setVeryLongAndVeryDetailedDescription(veryLongAndVeryDetailedDescription)
+      .setMandatoryDoubleWithoutDefault(mandatoryDoubleWithoutDefault)
 
   /**
    * Composes and builds a [Person] object.
    *
    * This is a concrete implementation of the builder design pattern.
-   *
-   * @property name The full name.
-   * @property nickname The nickname.
-   * @property age The age.
-   * @property veryLongAndVeryDetailedDescription The very long and very detailed description.
    */
-  public class Builder {
+  public class Builder(
     /**
-     * The full name.
+     * Parameter that will become constructor parameter.
      */
     @set:JvmSynthetic
-    public var name: String? = "John"
+    public var mandatoryDoubleWithoutDefault: Double
+  ) {
+    /**
+     * Name.
+     */
+    @set:JvmSynthetic
+    public var name: String = "John"
 
     /**
-     * The nickname.
+     * Nickname.
      */
     @set:JvmSynthetic
     public var nickname: String? = null
 
     /**
-     * The age.
+     * Age.
      */
     @set:JvmSynthetic
-    public var age: Int? = 23
+    public var age: Int = 23
 
     /**
-     * The very long and very detailed description.
      * Actually it's a very short description.
      */
     @set:JvmSynthetic
     public var veryLongAndVeryDetailedDescription: String? = null
 
     /**
-     * Set the full name.
+     * Setter for name: name.
      *
-     * @param name the full name.
+     * @param name
      * @return Builder
      */
-    public fun setName(name: String?): Builder {
+    public fun setName(name: String): Builder {
       this.name = name
       return this
     }
 
     /**
-     * Set the nickname.
+     * Setter for nickname: nickname.
      *
-     * @param nickname the nickname.
+     * @param nickname
      * @return Builder
      */
     public fun setNickname(nickname: String?): Builder {
@@ -126,21 +136,20 @@ public class Person private constructor(
     }
 
     /**
-     * Set the age.
+     * Setter for age: age.
      *
-     * @param age the age.
+     * @param age
      * @return Builder
      */
-    public fun setAge(age: Int?): Builder {
+    public fun setAge(age: Int): Builder {
       this.age = age
       return this
     }
 
     /**
-     * Set the very long and very detailed description.
-     * Actually it's a very short description.
+     * Setter for veryLongAndVeryDetailedDescription: actually it's a very short description.
      *
-     * @param veryLongAndVeryDetailedDescription the very long and very detailed description.
+     * @param veryLongAndVeryDetailedDescription
      * @return Builder
      */
     public fun setVeryLongAndVeryDetailedDescription(veryLongAndVeryDetailedDescription: String?):
@@ -150,21 +159,23 @@ public class Person private constructor(
     }
 
     /**
-     * Returns a [Person] reference to the object being constructed by the builder.
+     * Setter for mandatoryDoubleWithoutDefault: parameter that will become constructor parameter.
      *
-     * Throws an [IllegalArgumentException] when a non-null property wasn't initialised.
+     * @param mandatoryDoubleWithoutDefault
+     * @return Builder
+     */
+    public fun setMandatoryDoubleWithoutDefault(mandatoryDoubleWithoutDefault: Double): Builder {
+      this.mandatoryDoubleWithoutDefault = mandatoryDoubleWithoutDefault
+      return this
+    }
+
+    /**
+     * Returns a [Person] reference to the object being constructed by the builder.
      *
      * @return Person
      */
-    public fun build(): Person {
-      if (name==null) {
-      	throw IllegalArgumentException(""${"\""}Null name found when building Person.""${"\""}.trimIndent())
-      }
-      if (age==null) {
-      	throw IllegalArgumentException(""${"\""}Null age found when building Person.""${"\""}.trimIndent())
-      }
-      return Person(name!!, nickname, age!!, veryLongAndVeryDetailedDescription)
-    }
+    public fun build(): Person = Person(name, nickname, age, veryLongAndVeryDetailedDescription,
+        mandatoryDoubleWithoutDefault)
   }
 }
 
@@ -175,7 +186,7 @@ public class Person private constructor(
  * @return Person
  */
 @JvmSynthetic
-public fun Person(initializer: Person.Builder.() -> Unit): Person =
-    Person.Builder().apply(initializer).build()
+public fun Person(mandatoryDoubleWithoutDefault: Double, initializer: Person.Builder.() -> Unit):
+    Person = Person.Builder(mandatoryDoubleWithoutDefault).apply(initializer).build()
 
 """.trimIndent().replace('%', '$')


### PR DESCRIPTION
1. Use Double.compareTo and Float.compareTo when comparing these types in overloaded equals.
2. Builder setter methods should take into account whether given property is nullable. Now we always set nullable property and throw runtime exception when build() is called - this should be replaced with compile error.
3. If parameter is non-nullable and has no default value - it becomes Builder constructor parameter.
4. Javadoc looks nicer.