### PR TITLE
Add generateCompanionObject option to generate companion object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ And you will have to include the required dependencies:
 
 ```groovy
 dependencies {
-  implementation 'com.github.tobrun.kotlin-data-compat:annotation:0.8.0'
-  ksp 'com.github.tobrun.kotlin-data-compat:processor:0.8.0'
+  implementation 'com.github.tobrun.kotlin-data-compat:annotation:0.9.0'
+  ksp 'com.github.tobrun.kotlin-data-compat:processor:0.9.0'
 }
 ```
 

--- a/annotation/src/main/kotlin/com/tobrun/datacompat/annotation/DataCompat.kt
+++ b/annotation/src/main/kotlin/com/tobrun/datacompat/annotation/DataCompat.kt
@@ -6,7 +6,12 @@ package com.tobrun.datacompat.annotation
  *
  * @param importsForDefaults if any default values require additional imports, they should be passed here.
  *  E.g. `["android.graphics.Color"]`
+ * @param generateCompanionObject if enabled, a public companion object will be generated for the class,
+ *  so that user can then manually write extension functions to the Companion object. Defaults to false.
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
-annotation class DataCompat(val importsForDefaults: Array<String> = [])
+annotation class DataCompat(
+    val importsForDefaults: Array<String> = [],
+    val generateCompanionObject: Boolean = false
+)

--- a/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
+++ b/example/src/main/kotlin/com/tobrun/data/compat/example/PersonData.kt
@@ -12,7 +12,7 @@ annotation class SampleAnnotation
  * @property nickname The nickname.
  * @property age The age.
  */
-@DataCompat(importsForDefaults = ["java.util.Date"])
+@DataCompat(importsForDefaults = ["java.util.Date"], generateCompanionObject = true)
 @SampleAnnotation
 private data class PersonData(
     @Default("\"John\" + Date(1580897313933L).toString()")

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -297,11 +297,11 @@ class DataCompatProcessor(
                                 prefix = "return Builder($mandatoryParams)\n",
                                 transform = { str ->
                                     "${" ".repeat(INDENTATION_SIZE)}.set${
-                                        str.toString().replaceFirstChar {
-                                            if (it.isLowerCase())
-                                                it.titlecase(Locale.getDefault())
-                                            else it.toString()
-                                        }
+                                    str.toString().replaceFirstChar {
+                                        if (it.isLowerCase())
+                                            it.titlecase(Locale.getDefault())
+                                        else it.toString()
+                                    }
                                     }($str)"
                                 },
                                 separator = "\n",
@@ -373,16 +373,16 @@ class DataCompatProcessor(
                     FunSpec
                         .builder(
                             "set${
-                                propertyName.replaceFirstChar {
-                                    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-                                }
+                            propertyName.replaceFirstChar {
+                                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                            }
                             }"
                         )
                         .addKdoc(
                             """
                             |Setter for $propertyName: ${
-                                property.value.kDoc.trimEnd('.')
-                                    .replaceFirstChar { it.lowercase(Locale.getDefault()) }
+                            property.value.kDoc.trimEnd('.')
+                                .replaceFirstChar { it.lowercase(Locale.getDefault()) }
                             }.
                             |
                             |@param $propertyName

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -430,7 +430,14 @@ class DataCompatProcessor(
             classBuilder.addType(builderBuilder.build())
 
             if (generateCompanionObject) {
-                classBuilder.addType(TypeSpec.companionObjectBuilder().build())
+                classBuilder.addType(
+                    TypeSpec.companionObjectBuilder()
+                        .addKdoc(
+                            """
+                            Public Companion Object of [$className].
+                            """.trimIndent()
+                        ).build()
+                )
             }
 
             // initializer function

--- a/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
+++ b/processor/src/main/kotlin/com/tobrun/datacompat/DataCompatProcessor.kt
@@ -47,7 +47,8 @@ class DataCompatProcessor(
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         logger.info("DataCompat: process")
-        val dataCompatAnnotated = resolver.getSymbolsWithAnnotation(DataCompat::class.qualifiedName!!, true)
+        val dataCompatAnnotated =
+            resolver.getSymbolsWithAnnotation(DataCompat::class.qualifiedName!!, true)
         if (dataCompatAnnotated.count() == 0) {
             logger.info("DataCompat: No DataCompat annotations found for processing")
             return emptyList()
@@ -72,7 +73,8 @@ class DataCompatProcessor(
                 if (defaultValueMap == null) {
                     defaultValueMap = mutableMapOf()
                 }
-                val defaultAnnotationsParams = annotatedProperty.annotations.firstOrNull()?.arguments
+                val defaultAnnotationsParams =
+                    annotatedProperty.annotations.firstOrNull()?.arguments
                 val defaultValue = defaultAnnotationsParams?.first()
                 defaultValueMap[annotatedProperty.name!!.getShortName()] =
                     defaultValue?.value as? String?
@@ -114,10 +116,21 @@ class DataCompatProcessor(
             val classKdoc = classDeclaration.docString
             val packageName = classDeclaration.packageName.asString()
 
-            val imports = ArrayList<String>()
-            classDeclaration.annotations.firstOrNull {
+            val dataCompatAnnotation = classDeclaration.annotations.firstOrNull {
                 it.annotationType.resolve().toString() == DataCompat::class.simpleName
-            }?.arguments?.firstOrNull()?.value?.let { imports.addAll(it as ArrayList<String>) }
+            }
+            // Resolve list of imports from [DataCompat.importsForDefaults]
+            val imports = ArrayList<String>()
+            dataCompatAnnotation?.arguments?.firstOrNull {
+                it.name?.getShortName() == "importsForDefaults"
+            }?.value?.let { imports.addAll(it as ArrayList<String>) }
+
+            // Resolve generateCompanionObject flag from [DataCompat.generateCompanionObject]
+            var generateCompanionObject = false
+            dataCompatAnnotation?.arguments?.firstOrNull {
+                it.name?.getShortName() == "generateCompanionObject"
+            }?.value?.let { generateCompanionObject = it as Boolean }
+
             val otherAnnotations = classDeclaration.annotations
                 .filter { it.annotationType.resolve().toString() != DataCompat::class.simpleName }
             val implementedInterfaces = classDeclaration
@@ -133,7 +146,8 @@ class DataCompatProcessor(
                     typeName = typeName,
                     mandatoryForConstructor = defaultValuesMap[classDeclaration]
                         ?.get(property.toString()) == null && !typeName.isNullable,
-                    kDoc = property.docString?.trim(' ', '\n') ?: property.toString().capitalizeAndAddSpaces(),
+                    kDoc = property.docString?.trim(' ', '\n') ?: property.toString()
+                        .capitalizeAndAddSpaces(),
                 )
             }
 
@@ -280,15 +294,17 @@ class DataCompatProcessor(
                         )
                         .addStatement(
                             propertyMap.keys.joinToString(
-                                prefix = "return Builder($mandatoryParams) .",
+                                prefix = "return Builder($mandatoryParams)\n",
                                 transform = { str ->
-                                    "set${str.toString().replaceFirstChar {
-                                        if (it.isLowerCase())
-                                            it.titlecase(Locale.getDefault())
-                                        else it.toString()
-                                    }}($str)"
+                                    "${" ".repeat(INDENTATION_SIZE)}.set${
+                                        str.toString().replaceFirstChar {
+                                            if (it.isLowerCase())
+                                                it.titlecase(Locale.getDefault())
+                                            else it.toString()
+                                        }
+                                    }($str)"
                                 },
-                                separator = " .",
+                                separator = "\n",
                             )
                         )
                         .returns(ClassName("", "Builder"))
@@ -332,7 +348,10 @@ class DataCompatProcessor(
                         PropertySpec.builder(propertyName, property.value.typeName)
                             .initializer(
                                 CodeBlock.builder()
-                                    .add(defaultValuesMap[classDeclaration]?.get(propertyName) ?: "null")
+                                    .add(
+                                        defaultValuesMap[classDeclaration]?.get(propertyName)
+                                            ?: "null"
+                                    )
                                     .build()
                             )
                             .addKdoc(
@@ -353,14 +372,18 @@ class DataCompatProcessor(
                 builderBuilder.addFunction(
                     FunSpec
                         .builder(
-                            "set${propertyName.replaceFirstChar {
-                                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-                            }}"
+                            "set${
+                                propertyName.replaceFirstChar {
+                                    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                                }
+                            }"
                         )
                         .addKdoc(
                             """
-                            |Setter for $propertyName: ${property.value.kDoc.trimEnd('.')
-                                .replaceFirstChar { it.lowercase(Locale.getDefault()) }}.
+                            |Setter for $propertyName: ${
+                                property.value.kDoc.trimEnd('.')
+                                    .replaceFirstChar { it.lowercase(Locale.getDefault()) }
+                            }.
                             |
                             |@param $propertyName
                             |@return Builder
@@ -405,6 +428,10 @@ class DataCompatProcessor(
             builderBuilder.addFunction(buildFunction.build())
 
             classBuilder.addType(builderBuilder.build())
+
+            if (generateCompanionObject) {
+                classBuilder.addType(TypeSpec.companionObjectBuilder().build())
+            }
 
             // initializer function
             val initializerFunctionBuilder = FunSpec.builder(className)
@@ -527,5 +554,6 @@ class DataCompatProcessor(
 
     private companion object {
         private const val CLASS_NAME_DROP_LAST_CHARACTERS = 4
+        private const val INDENTATION_SIZE = 2
     }
 }

--- a/processor/src/test/kotlin/com/tobrun/datacompat/DataCompatProcessorTest.kt
+++ b/processor/src/test/kotlin/com/tobrun/datacompat/DataCompatProcessorTest.kt
@@ -26,7 +26,7 @@ interface EmptyInterface2
  * @property veryLongAndVeryDetailedDescription The very long and very detailed description.
  */
 @Deprecated
-@DataCompat(importsForDefaults = ["java.util.Date"])
+@DataCompat(importsForDefaults = ["java.util.Date"], generateCompanionObject = true)
 private data class PersonData(
     @Default("\"John\"")
     val name: String,

--- a/processor/src/test/kotlin/com/tobrun/datacompat/SimpleTestContent.kt
+++ b/processor/src/test/kotlin/com/tobrun/datacompat/SimpleTestContent.kt
@@ -179,6 +179,11 @@ public class Person private constructor(
     public fun build(): Person = Person(name, nickname, age, veryLongAndVeryDetailedDescription,
         mandatoryDoubleWithoutDefault)
   }
+
+  /**
+   * Public Companion Object of [Person].
+   */
+  public companion object
 }
 
 /**

--- a/processor/src/test/kotlin/com/tobrun/datacompat/SimpleTestContent.kt
+++ b/processor/src/test/kotlin/com/tobrun/datacompat/SimpleTestContent.kt
@@ -72,10 +72,12 @@ public class Person private constructor(
   /**
    * Convert to Builder allowing to change class properties.
    */
-  public fun toBuilder(): Builder = Builder(mandatoryDoubleWithoutDefault) .setName(name)
-      .setNickname(nickname) .setAge(age)
-      .setVeryLongAndVeryDetailedDescription(veryLongAndVeryDetailedDescription)
-      .setMandatoryDoubleWithoutDefault(mandatoryDoubleWithoutDefault)
+  public fun toBuilder(): Builder = Builder(mandatoryDoubleWithoutDefault)
+    .setName(name)
+    .setNickname(nickname)
+    .setAge(age)
+    .setVeryLongAndVeryDetailedDescription(veryLongAndVeryDetailedDescription)
+    .setMandatoryDoubleWithoutDefault(mandatoryDoubleWithoutDefault)
 
   /**
    * Composes and builds a [Person] object.

--- a/processor/src/test/kotlin/com/tobrun/datacompat/TestAnnotation.kt
+++ b/processor/src/test/kotlin/com/tobrun/datacompat/TestAnnotation.kt
@@ -9,7 +9,10 @@ package com.tobrun.datacompat.annotation
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
-annotation class DataCompat(val importsForDefaults: Array<String> = [])
+annotation class DataCompat(
+    val importsForDefaults: Array<String> = [],
+    val generateCompanionObject: Boolean = false
+)
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.VALUE_PARAMETER)


### PR DESCRIPTION
Sometimes it's useful to generate a public companion object for the class, as it allows static extension functions to be added to the class.

Users can do extensions like:

```
fun Person.Companion.fromHuman(human: Human) : Person

// and use it like
val person = Person.fromHuman(human)
```


This PR also fixes the format of toBuilder() function.